### PR TITLE
cwifiserver.cc: Bound signal level to appropriate value

### DIFF
--- a/src/cwifiserver.cc
+++ b/src/cwifiserver.cc
@@ -202,6 +202,10 @@ void CWifiServer::SendAllOtherClients(TIndex index,TPower power, const char* dat
 			{
 				TFrequency frequency=GetFrequency((struct nlmsghdr*)data);
 				TPower signalLevel=BoundedPower(power-Attenuation(coo.DistanceWith((*InfoWifis)[i]),frequency));
+
+				if (signalLevel > 0)
+					signalLevel = -10;
+
 				if( ! CanLostPackets || ! PacketIsLost(signalLevel) )
 					if( SendSignal((*InfoSockets)[i].GetDescriptor(), &signalLevel, data, sizeOfData) < 0 )
 						(*InfoSockets)[i].DisableIt();


### PR DESCRIPTION
If the distance between two clients is low it can result in the signal level being greater than zero. This doesn't make sense as dBm is always a negative value. On the client side passing a >0 value to the kernel as the signal results in extreme signal levels reported (likely due to a signed/unsigned conversion somewhere).

Check the calculated signal and if greater than zero bound to -10.