### PR TITLE
Use named field assignments to support glibc and musl

### DIFF
--- a/src/cmonwirelessdevice.cc
+++ b/src/cmonwirelessdevice.cc
@@ -207,7 +207,11 @@ void MonitorWirelessDevice::recv_inet_event()
 	char buf[IFLIST_REPLY_BUFFER];
 	struct iovec iov = { buf, sizeof(buf) };
 	struct sockaddr_nl snl;
-	struct msghdr msg = { static_cast<void *>(&snl), sizeof(snl), &iov, 1, NULL, 0, 0 };
+	struct msghdr msg = {};
+	msg.msg_name    = static_cast<void *>(&snl);
+	msg.msg_namelen = sizeof(snl);
+	msg.msg_iov     = &iov;
+	msg.msg_iovlen  = 1;
 	struct nlmsghdr *nlmsgheader;
 
 	/* read the waiting message */


### PR DESCRIPTION
This change would fix the need for the ugly patch mentioned on the wiki. When the code is compiled at `-O2` the produced assembly is identical. 