### PR TITLE
build.yaml : Create github workflow file

### DIFF
--- a/.github/workflows/build-openwrt.yaml
+++ b/.github/workflows/build-openwrt.yaml
@@ -1,0 +1,83 @@
+name: Build OpenWRT
+on:
+  - push
+env:
+  STAGING_DIR: /tmp
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-versions.outputs.versions }}
+    steps:
+      - name: Get OpenWRT versions
+        id: get-versions
+        run: |
+          VERSIONS=$(curl https://sysupgrade.openwrt.org/json/v1/overview.json | jq -c '.latest')
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+  build:
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.prepare.outputs.versions) }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zstd unzip
+          sudo apt-get install -y make bison flex
+          sudo apt-get install -y cmake pkg-config
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install python dependencies
+        run:  pip install bs4 requests
+      - name: Setup build directory
+        run: mkdir build
+      - name: Download needed files
+        run: |
+          SDK_URL=$(python .github/workflows/scripts/openwrt_download_finder.py sdk ${{ matrix.version }} x86 64)
+          TOOLCHAIN_URL=$(python .github/workflows/scripts/openwrt_download_finder.py toolchain ${{ matrix.version }} x86 64)
+          cd build
+          wget $SDK_URL -O SDK.tar.zst
+          wget $TOOLCHAIN_URL -O TOOLCHAIN.tar.zst
+          tar -xf SDK.tar.zst
+          tar -xf TOOLCHAIN.tar.zst
+          mv openwrt-sdk-* SDK
+          mv openwrt-toolchain-* TOOLCHAIN
+          ls TOOLCHAIN
+          echo $(find ${PWD}/TOOLCHAIN -name "toolchain-*")/bin >> $GITHUB_PATH
+          wget https://github.com/thom311/libnl/releases/download/libnl3_12_0/libnl-3.12.0.tar.gz
+          tar xf libnl-3.12.0.tar.gz
+          mv libnl-3.12.0 libnlsrc
+
+      - name: Build libnl
+        run: |
+          cd build/libnlsrc
+          ./configure --prefix=${GITHUB_WORKSPACE}/build/LIBNL --build=x86_64-unknown-linux-gnu  --host=x86_64-openwrt-linux-musl LDFLAGS="-static"
+          make
+          cd ..
+          mkdir LIBNL
+          ln -s ${GITHUB_WORKSPACE}/build/libnlsrc/lib/.libs ${GITHUB_WORKSPACE}/build/LIBNL/lib
+          ln -s ${GITHUB_WORKSPACE}/build/libnlsrc/include ${GITHUB_WORKSPACE}/build/LIBNL/include
+          ln -s ${GITHUB_WORKSPACE}/build/LIBNL/lib ${GITHUB_WORKSPACE}/build/LIBNL/include/libnl3
+      - name: Build
+        run: |
+          cd build
+          export PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/build/libnlsrc
+          echo $PATH
+          ls TOOLCHAIN/*
+          cmake .. \
+            -DCMAKE_CXX_COMPILER=x86_64-openwrt-linux-musl-g++ \
+            -DCMAKE_EXE_LINKER_FLAGS="-L${GITHUB_WORKSPACE}/build/LIBNL/lib -lnl-genl-3 -lnl-3" \
+            -DCMAKE_CXX_FLAGS="-I${GITHUB_WORKSPACE}/build/LIBNL/include"
+          make
+      - name: Upload
+        uses: actions/upload-artifact@v5
+        with:
+          path: build/vwifi-*
+          name: OpenWRT ${{ matrix.version }} binaries
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Build
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake make g++ pkg-config
+          sudo apt-get install -y libnl-3-dev libnl-genl-3-dev
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+      - name: Upload
+        uses: actions/upload-artifact@v5
+        with:
+          path: build/vwifi-*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-26.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
         uses: actions/checkout@v7
@@ -23,3 +26,4 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           path: build/vwifi-*
+          name: ${{ matrix.os }} binaries

--- a/.github/workflows/scripts/openwrt_download_finder.py
+++ b/.github/workflows/scripts/openwrt_download_finder.py
@@ -1,0 +1,25 @@
+import sys
+from urllib.parse import urljoin
+import requests
+from bs4 import BeautifulSoup
+
+def url(file, version, target, subtarget):
+    base = (
+        f"https://downloads.openwrt.org/releases/"
+        f"{version}/targets/{target}/{subtarget}/"
+    )
+
+    r = requests.get(base, timeout=10)
+    r.raise_for_status()
+
+    soup = BeautifulSoup(r.text, "html.parser")
+
+    for a in soup.find_all("a"):
+        href = a.get("href", "")
+        if href.startswith(f"openwrt-{file}-") and href.endswith(".tar.zst"):
+            return urljoin(base, href)
+
+    raise RuntimeError(f"{file} not found")
+
+if __name__ == "__main__":
+    print(url(*sys.argv[1:]))


### PR DESCRIPTION
This PR adds workflows to build vwifi for Ubuntu latest (24.04) and 26.04; as well as the current and previous stable releases of OpenWRT. If desired I would extend these to update the releases when tags are pushed. 

Future updates should build packages for Ubuntu (also compatible with the GNS3 VM) and OpenWRT including the service files. 
