### PR TITLE
Nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ cmake ..
 
 * See the wiki : [Install-vwifi-on-OpenWRT-X86_64](https://github.com/Raizo62/vwifi/wiki/Install-on-OpenWRT-X86_64)
 
+## Using Nix
+
+If you are using NixOS or have the Nix package manager installed, you can enter a development environment with all the necessary dependencies by running the following command from the root of the repository:
+
+```bash
+nix-shell nix/shell.nix
+```
+
+This will download and set up all required build tools and libraries specified in `nix/shell.nix`. Once inside the shell, you can follow the standard building instructions (CMake, make, etc.).
+
 # Configuration
 
 ## Method 1 : With VHOST

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ cmake ..
 
 ## Using Nix
 
-If you are using NixOS or have the Nix package manager installed, you can enter a development environment with all the necessary dependencies by running the following command from the root of the repository:
+If you have the Nix package manager installed, you can enter a development environment with all the necessary dependencies by running the following command from the root of the repository:
 
 ```bash
-nix-shell nix/shell.nix
+nix-shell tools
 ```
 
-This will download and set up all required build tools and libraries specified in `nix/shell.nix`. Once inside the shell, you can follow the standard building instructions (CMake, make, etc.).
+This will download and set up all required build tools and libraries specified in `tools/shell.nix`. Once inside the shell, you can follow the building instructions above (CMake, make, etc.).
 
 # Configuration
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,22 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    # Build tools
+    cmake
+    gcc
+    gnumake
+    pkg-config
+
+    # Required libraries
+    libnl # For netlink functionality
+    
+    # Development tools
+    gdb
+    valgrind
+    cppcheck
+    libxslt
+  ];
+
+
+} 

--- a/tools/shell.nix
+++ b/tools/shell.nix
@@ -1,22 +1,22 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.mkShell {
-  buildInputs = with pkgs; [
-    # Build tools
+  # Build tools
+  nativeBuildInputs = with pkgs; [
     cmake
-    gcc
-    gnumake
     pkg-config
+  ];
 
+  buildInputs = with pkgs; [
     # Required libraries
     libnl # For netlink functionality
-    
+
     # Development tools
     gdb
     valgrind
     cppcheck
     libxslt
   ];
-
-
-} 
+}


### PR DESCRIPTION
Follow-up of #19:

Added Nix Support for development, with corresponding instructions in the README.

Tested on NixOS 26.05 with success, after a rebase, to account the updated build instructions (cmake).